### PR TITLE
Add ability to access info using URL /name/version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.0.2",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -4106,6 +4107,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -14576,6 +14582,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.2.tgz",
+      "integrity": "sha512-VJOQ+CDWFDGaWdrG12Nl+d7yHtLaurNgAQZVgaIy7/Xd+DojgmYLosFfZdGz1wpxmjJIAkAMVTKWcvkx1oggAw==",
+      "dependencies": {
+        "react-router": "7.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15483,6 +15535,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -16806,6 +16863,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dotenv": "^16.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.0.2",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,20 @@
 import Kamai from './kamai.js';
-
+import withRouterParams from "./withRouterParams";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import './App.css';
+
+const KamaiWithRouter = withRouterParams(Kamai);
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
-        <Kamai></Kamai>
+        <Router>
+          <Routes>
+            <Route path="/:name/:version?" element={<KamaiWithRouter/>} />
+            <Route path="/" element={<KamaiWithRouter/>} />
+          </Routes>
+        </Router>
       </header>
     </div>
   );

--- a/src/kamai.js
+++ b/src/kamai.js
@@ -17,12 +17,44 @@ class Kamai extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
+  handleVersion = (urlVersion, type) => { // Switch between version strings for use in calling API or formatting in URL
+    const versionMap = {
+      "1": { formatted: "bright MEMORY Act.1", pretty: "act1" },
+      "2": { formatted: "bright MEMORY Act.2", pretty: "act2" },
+      "3": { formatted: "bright MEMORY Act.3", pretty: "act3" }
+    };
+  
+    let result = { formatted: "bright MEMORY Act.3", pretty: "act3" };
+  
+    Object.keys(versionMap).forEach((key) => {
+      if (urlVersion.includes(key)) {
+        result = versionMap[key];
+      }
+    });
+  
+    return result[type];
+  };
+
   componentDidMount() {
-    const userName = sessionStorage.getItem("userName");
-    if (userName) {
-      this.setState({userName: userName}, () => {
+    if (this.props.params.name && this.props.params.version) { // Check URL param /name/version on mount and update state
+      let version = this.handleVersion(this.props.params.version, "formatted")
+      this.setState({userName: this.props.params.name, version: version}, () => {
         this.apiCall()
       })
+    }
+    else if (this.props.params.name){ // For /name only
+      this.setState({userName: this.props.params.name}, () => {
+        this.apiCall()
+      })
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    let versions = ["act1", "act2", "act3"] // Update version param in URL if formatted differently than actx
+
+    if (this.props.params.version && (!versions.includes(this.props.params.version))) {
+      let standardizedVersion = this.handleVersion(this.props.params.version, "pretty")
+      this.props.navigate(`/${this.state.userName}/${standardizedVersion}`, { replace: true })
     }
   }
 
@@ -63,11 +95,11 @@ class Kamai extends Component {
       submitted: true,
       errorUsername: null
     })
-    sessionStorage.setItem("userName", this.state.userName);
+    let standardizedVersion = this.handleVersion(this.state.version, "pretty")
+    this.props.navigate(`/${this.state.userName}/${standardizedVersion}`)
   }
 
   handleBack = (e) => {
-    sessionStorage.removeItem("userName");
     this.setState({
       scores: [],
       recents: [],
@@ -78,6 +110,7 @@ class Kamai extends Component {
       version: "bright MEMORY Act.3",
       errorUsername: null
     })
+    this.props.navigate(`/`);
   }
 
   render() {    

--- a/src/withRouterParams.js
+++ b/src/withRouterParams.js
@@ -1,0 +1,10 @@
+import React from "react";
+import { useParams, useNavigate } from "react-router-dom";
+
+const withRouterParams = (Wrapped) => (props) => {
+  const params = useParams();
+  const navigate = useNavigate();
+  return <Wrapped {...props} params={params} navigate={navigate} />;
+};
+
+export default withRouterParams;


### PR DESCRIPTION
- B45 can now be accessed directly through the URL in the form of "/username/version"
- If only "/username" is provided, site defaults to showing Act 3 information
- Any version parameter with 1, 2, or 3 in it will be handled and reformatted to actx in the URL
- If the version parameter has multiple numbers, site will prioritize newer Act numbers (e.g. /name/32 -> Act 3, /name/12 -> Act 2)