### PR TITLE
Add functionality to Score Simulator V2 calculator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,15 @@
     transform: rotate(360deg);
   }
 }
+
+.vertical-radio-buttons label {
+  display: block; /* Stacks labels vertically */
+  margin-bottom: 10px; /* Optional spacing */
+}
+
+.divStyle {
+  display: grid;
+  border-style: solid;
+  text-align: center;
+  padding: 10px;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import Kamai from "./kamai.js";
 import Leaderboard from "./leaderboard.js";
 import ScoreSimulator from "./scoresimulator.js";
+import ScoreSimulatorV2 from "./scoresimulatorV2.js";
 
 import withRouterParams from "./withRouterParams";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
@@ -10,6 +11,7 @@ import "./App.css";
 const KamaiWithRouter = withRouterParams(Kamai);
 const LeaderboardWithRouter = withRouterParams(Leaderboard);
 const ScoreSimulatorWithRouter = withRouterParams(ScoreSimulator);
+const ScoreSimulatorWithRouterV2 = withRouterParams(ScoreSimulatorV2);
 
 function App() {
   return (
@@ -24,6 +26,10 @@ function App() {
             <Route
               path="/scoresimulator"
               element={<ScoreSimulatorWithRouter />}
+            />
+                        <Route
+              path="/scoresimulatorv2"
+              element={<ScoreSimulatorWithRouterV2 />}
             />
           </Routes>
         </Router>

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -45,6 +45,12 @@ class Navbar extends Component {
                     </Button>
                 </Link>
 
+                <Link to="/scoresimulatorv2" style={{ textDecoration: 'none' }}>
+                    <Button sx={{ my: 2, color: 'white', display: 'block' }}>
+                        Score Simulator Refresh
+                    </Button>
+                </Link>
+
             </Toolbar>
         </AppBar>
         <Toolbar />

--- a/src/OngekiRefresh.js
+++ b/src/OngekiRefresh.js
@@ -3,7 +3,7 @@ import Grid from "@mui/material/Grid2";
 import data from "./data.json";
 import { toPng } from 'html-to-image';
 import ScoreSimulator from "./scoresimulator";
-class Ongeki extends Component {
+class OngekiRefresh extends Component {
   constructor(props) {
     super(props);
     this.ref = createRef();
@@ -155,12 +155,14 @@ class Ongeki extends Component {
     for (let i = 0; i < combinedJson.length; i++) {
       if (
         combinedJson[i].chart.data.displayVersion === latestVersion &&
-        latestJson.length !== 15 &&
+        latestJson.length !== 10 &&
         !set3.has(combinedJson[i].score.songID)
       ) {
         set3.add(combinedJson[i].score.songID);
         latestJson.push(this.createSongJson(i, combinedJson));
         latestVersionArray.push(combinedJson[i].score.calculatedData.rating);
+
+        console.log("Latest LENGTH", latestVersionArray.length)
       }
     }
 
@@ -180,7 +182,7 @@ class Ongeki extends Component {
     const recentDataJson = this.combineRecentJson(this.state.recents);
     let set5 = new Set();
     for (let i = 0; i < recentDataJson.length; i++) {
-      if (recentArray.length !== 10) {
+      if (recentArray.length !== 50) {
         set5.add(recentDataJson[i].score.songID);
         recentJson.push(this.createSongJson(i, recentDataJson));
         recentArray.push(recentDataJson[i].score.calculatedData.rating);
@@ -188,7 +190,7 @@ class Ongeki extends Component {
     }
 
     let bestSum = bestArray.reduce((a, b) => a + b, 0) / 30;
-    let latestSum = latestVersionArray.reduce((a, b) => a + b, 0) / 15;
+    let latestSum = latestVersionArray.reduce((a, b) => a + b, 0) / 10;
     let recentSum = recentArray.reduce((a, b) => a + b, 0) / 10;
     let totalScore = (bestSum + latestSum + recentSum) / 3;
     const allJson = [];
@@ -426,7 +428,7 @@ class Ongeki extends Component {
           </Grid>
 
         </div>
-          <p style={{ textAlign: "left" }}>Recent: {scores[2]}</p>
+          <p style={{ textAlign: "left" }}>P-Score: {scores[2]}</p>
           <Grid container spacing={2}>
             {recent}
           </Grid>
@@ -438,4 +440,4 @@ class Ongeki extends Component {
   }
 }
 
-export default Ongeki;
+export default OngekiRefresh;

--- a/src/kamai.js
+++ b/src/kamai.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import Ongeki from "./ongeki.js";
+// import Ongeki from "./ongeki.js";
 import OngekiRefresh from "./OngekiRefresh.js";
 
 class Kamai extends Component {

--- a/src/kamai.js
+++ b/src/kamai.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import Ongeki from "./ongeki.js";
+import OngekiRefresh from "./OngekiRefresh.js";
 
 class Kamai extends Component {
   constructor(props) {
@@ -10,7 +11,7 @@ class Kamai extends Component {
       error: null,
       userName: null,
       value: null,
-      version: "オンゲキ bright MEMORY Act.3",
+      version: "オンゲキ Re:Fresh",
       errorUsername: null,
     };
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -22,9 +23,11 @@ class Kamai extends Component {
       "1": { formatted: "オンゲキ bright MEMORY Act.1", pretty: "act1" },
       "2": { formatted: "オンゲキ bright MEMORY Act.2", pretty: "act2" },
       "3": { formatted: "オンゲキ bright MEMORY Act.3", pretty: "act3" },
+      "4": { formatted: "オンゲキ Re:Fresh", pretty: "refresh" },
+
     };
 
-    let result = { formatted: "オンゲキ bright MEMORY Act.3", pretty: "act3" };
+    let result = { formatted: "オンゲキ Re:Fresh", pretty: "refresh" };
 
     Object.keys(versionMap).forEach((key) => {
       if (urlVersion.includes(key)) {
@@ -54,7 +57,7 @@ class Kamai extends Component {
   }
 
   componentDidUpdate() {
-    let versions = ["act1", "act2", "act3"]; // Update version param in URL if formatted differently than actx
+    let versions = ["act1", "act2", "act3", "refresh"]; // Update version param in URL if formatted differently than actx
 
     if (
       this.props.params.version &&
@@ -141,13 +144,13 @@ class Kamai extends Component {
         errorMessage = `Error, current user does not exist in the database.`;
       } else {
         return (
-          <Ongeki
+          <OngekiRefresh
             scores={this.state.scores}
             handleBack={this.handleBack}
             recents={this.state.recents}
             version={this.state.version}
             userName={this.state.userName}
-          ></Ongeki>
+          ></OngekiRefresh>
         );
       }
     }
@@ -167,6 +170,7 @@ class Kamai extends Component {
               value={this.state.version}
               onChange={this.handleSelectChange}
             >
+              <option value="オンゲキ Re:Fresh">Refresh</option>
               <option value="オンゲキ bright MEMORY Act.3">Act 3</option>
               <option value="オンゲキ bright MEMORY Act.2">Act 2</option>
               <option value="オンゲキ bright MEMORY Act.1">Act 1</option>

--- a/src/kamai.js
+++ b/src/kamai.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
-// import Ongeki from "./ongeki.js";
-import OngekiRefresh from "./OngekiRefresh.js";
+import Ongeki from "./ongeki.js";
+// import OngekiRefresh from "./OngekiRefresh.js";
 
 class Kamai extends Component {
   constructor(props) {
@@ -144,13 +144,13 @@ class Kamai extends Component {
         errorMessage = `Error, current user does not exist in the database.`;
       } else {
         return (
-          <OngekiRefresh
+          <Ongeki
             scores={this.state.scores}
             handleBack={this.handleBack}
             recents={this.state.recents}
             version={this.state.version}
             userName={this.state.userName}
-          ></OngekiRefresh>
+          ></Ongeki>
         );
       }
     }

--- a/src/scoresimulatorV2.js
+++ b/src/scoresimulatorV2.js
@@ -6,210 +6,258 @@ class ScoreSimulatorV2 extends Component {
     super(props);
     this.state = {
       values: null,
-      critical: 0,
-      break: 0,
-      hit: 0,
-      miss: 0,
-      bell: 1,
-      totalBell: 1,
-      damage: 0,
+      chartRating: 0,
       score: 0,
-      chart: 1,
-      score2: 0,
-      rating: 0,
-      userName: null,
-      version: null,
-      score2Once: false
+      technicalRankBonus: null,
+      clearBadge: null, 
+      fullBell: false,
+      platinumScore: 0,
+      baseRating: 0,
+      platinumRating: 0
     };
-  }
+  }  // TODO: Inputs don't handle non-numbers well
 
-  componentDidMount() {
-    if (this.props.values !== undefined) {
-      this.setState({
-        critical: this.props.values[0],
-        break: this.props.values[1],
-        hit: this.props.values[2],
-        miss: this.props.values[3],
-        bell: this.props.values[4],
-        totalBell: this.props.values[5],
-        damage: this.props.values[6],
-        chart: this.props.values[7],
-        score2: this.props.values[8]
-    })
-    }
-  }
-  componentDidUpdate() {
-    let notePercent =
-      this.state.critical * 1 +
-      this.state.break * 0.9 +
-      this.state.hit * 0.6 +
-      this.state.miss * 0;
-    let totalNotes =
-      this.state.critical * 1 +
-      this.state.break * 1 +
-      this.state.hit * 1 +
-      this.state.miss * 1;
-    let acc = notePercent / totalNotes;
-    let noteScore = 950000 * acc;
-    let bellScore = (this.state.bell / this.state.totalBell) * 60000;
-    let damageScore = this.state.damage * 10;
-    let totalScore = this.state.score;
-    totalScore = noteScore + bellScore - damageScore;
+  // componentDidMount() {
+  //   if (this.props.values !== undefined) {
+  //     this.setState({
+  //       critical: this.props.values[0],
+  //       break: this.props.values[1],
+  //       hit: this.props.values[2],
+  //       miss: this.props.values[3],
+  //       bell: this.props.values[4],
+  //       totalBell: this.props.values[5],
+  //       damage: this.props.values[6],
+  //       chart: this.props.values[7],
+  //       score2: this.props.values[8]
+  //   })
+  //   }
+  // }
 
-    let musicRate;
-    if (this.state.score2 >= 1007500) {
-      musicRate = 2;
-    } else if (this.state.score2 >= 1000000) {
-      musicRate = 1.5 + (this.state.score2 - 1000000) / 15000;
-    } else if (this.state.score2 >= 990000) {
-      musicRate = 1 + (this.state.score2 - 990000) / 20000;
-    } else if (this.state.score2 >= 970000) {
-      musicRate = (this.state.score2 - 970000) / 20000;
+  calculateTechnicalScoreBonus(score) {
+    let bonus;
+    if (score >= 1010000) {
+      bonus = 2
+    } else if (score >= 1007500) {
+      bonus = 1.75 + (2 - 1.75) * (score - 1007500) / (1010000 - 1007500)
+    } else if (score >= 1000000) {
+      bonus = 1.25 + (1.75 - 1.25) * (score - 1000000) / (1007500 - 1000000)
+    } else if (score >= 990000) {
+      bonus = 0.75 + (1.25 - 0.75) * (score - 990000) / (1000000 - 990000)
+    } else if (score >= 970000) {
+      bonus = 0 + (0.75 - 0) * (score - 970000) / (990000 - 970000)
+    } else if (score >= 900000) {
+      bonus = -4 + (0 - -4) * (score - 900000) / (970000 - 900000) // TODO: Double check linear interpolation for negative nums here
+    } else if (score >= 800000) {
+      bonus = -6 + (-4 - -6) * (score - 800000) / (900000 - 800000) 
     } else {
-      musicRate = (this.state.score2 - 970000) / 17500;
+      bonus = 0
     }
-    musicRate += this.state.chart * 1;
+    return bonus
+  }
 
-    if (totalScore !== this.state.score && !isNaN(totalScore)) {
-      this.setState({ score: totalScore });
+  mapTechnicalRankBonus(technicalRankBonus) {
+    let bonus = 0;
+    if (technicalRankBonus === "SSS+"){
+      bonus = 0.3
+    } else if (technicalRankBonus === "SSS"){
+      bonus = 0.2
+    } else if (technicalRankBonus === "SS"){
+      bonus = 0.1
+    }
+    return bonus
+  }
+
+  mapClearBadgeBonus(clearBadge) {
+    let bonus = 0;
+    if (clearBadge === "All Break+"){
+      bonus = 0.35
+    } else if (clearBadge === "All Break"){
+      bonus = 0.3
+    } else if (clearBadge === "Full Combo"){
+      bonus = 0.1
+    }
+    return bonus
+  }
+
+  mapPlatinumScore(platinumScore, chartRating) {
+    let platinumBonus = 0;
+    if (platinumScore >= 0.98){
+      platinumBonus = 5
+    } else if (platinumScore >= 0.97){
+      platinumBonus = 4
+    } else if (platinumScore >= 0.96){
+      platinumBonus = 3
+    } else if (platinumScore >= 0.95){
+      platinumBonus = 2
+    } else if (platinumScore >= 0.94){
+      platinumBonus = 1
     }
 
-    if ((musicRate !== this.state.rating) && !isNaN(musicRate)) {
-      this.setState({ rating: musicRate });
+    return platinumBonus * chartRating * chartRating / 1000 // Platinum rating
+  }
+  
+  componentDidUpdate() {
+    let baseRating = 0;
+    let fullBell = 0;
+
+    if (this.state.fullBell){
+      fullBell = 0.05
+    }
+
+    if (this.state.score > 800000){
+      baseRating = (parseFloat(this.state.chartRating) + this.calculateTechnicalScoreBonus(this.state.score) + this.mapTechnicalRankBonus(this.state.technicalRankBonus) + 
+      this.mapClearBadgeBonus(this.state.clearBadge) + fullBell) / 5 // TODO: Where does 5 come from in the blog example?
+    } else if (this.state.score > 500000) {
+      baseRating = (this.state.chartRating - 6) * (this.state.score - 500000) / 300000
+    } else {
+      baseRating = 0
+    }
+
+    let platinumRating = this.mapPlatinumScore(this.state.platinumScore, this.state.chartRating)
+
+    if (baseRating !== this.state.baseRating && !isNaN(baseRating)) {
+      this.setState({ baseRating: baseRating });
+    }
+    if (platinumRating !== this.state.platinumRating && !isNaN(platinumRating)) {
+      this.setState({ platinumRating: platinumRating });
     }
   }
 
-  
   handleChange = (e) => {
     this.setState({ [e.target.name]: e.target.value });
   };
+
+  handleTechnicalRadio = (e) => {
+    const value = e.target.value;
+    this.setState(() => ({
+      technicalRankBonus: this.state.technicalRankBonus === value ? null : value
+    }));
+  }
+  
+  handleClearRadio = (e) => {
+    const value = e.target.value;
+    this.setState(() => ({
+      clearBadge: this.state.clearBadge === value ? null : value
+    }));
+  }
+
+  handleCheckbox = (e) => {
+    this.setState({ fullBell: !this.state.fullBell });
+  }
 
   handleBack = () => {
     //hacky solution I love react! 
    window.location = `https://ongekiers.netlify.app/${this.props.userName}/${this.props.version}`
   }
 
-    handleFileChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-            const jsonString = e.target.result;
-            const jsonData = JSON.parse(jsonString);
-            // Handle the jsonData here
-            console.log(jsonData);
-        } catch (error) {
-          console.error("Error parsing JSON:", error);
-        }
+  // handleFileChange = (event) => {
+  //   const file = event.target.files[0];
+  //   if (file) {
+  //     const reader = new FileReader();
+  //     reader.onload = (e) => {
+  //       try {
+  //           const jsonString = e.target.result;
+  //           const jsonData = JSON.parse(jsonString);
+  //           // Handle the jsonData here
+  //           console.log(jsonData);
+  //       } catch (error) {
+  //         console.error("Error parsing JSON:", error);
+  //       }
   
-      };
-      reader.readAsText(file);
-    }
-  };
+  //     };
+  //     reader.readAsText(file);
+  //   }
+  // };
 
   render() {
+    const divStyle = {
+      display: "grid",
+      borderStyle: "solid",
+      textAlign: "center",
+      padding: "10px",
+    };
 
-    return( 
-        <div className="divStyle">
-        <form>
-        <label>Chart Rating</label>
+    let { technicalRankBonus, clearBadge } = this.state;
 
-          <input
-            type="number"
-            name={"critical"}
-            value={this.state.critical}
-            onChange={this.handleChange}
-          ></input>
+    return ( 
+      <div>
+        <div>
+          <form style={divStyle}>
+            <label>Chart Rating</label>
+              <input
+                type="number"
+                name={"chartRating"}
+                value={this.state.chartRating}
+                onChange={this.handleChange}
+              />
 
-        <label>Score</label>
-          <input
-            type="number"
-            name={"critical"}
-            value={this.state.critical}
-            onChange={this.handleChange}
-          ></input>
+            <label>Score</label>
+              <input
+                type="number"
+                name={"score"}
+                value={this.state.score}
+                onChange={this.handleChange}
+              />
 
-
-
-        <div className="vertical-radio-buttons">
-            Technical Rank Bonus
-            <label>
-                SSS+
-                <input type="radio" name="choice" value="A" />
-            </label>
-            <label>
-                SSS
-                <input type="radio" name="choice" value="B" /> 
-            </label>
-            <label>
-                SS
-                <input type="radio" name="choice" value="C" />
-            </label>
+            <div className="vertical-radio-buttons">
+              Technical Rank
+              <label>
+                  SSS+
+                  <input type="radio" name="technicalRankBonus" value="SSS+" checked={technicalRankBonus === "SSS+"} onClick={this.handleTechnicalRadio} readOnly/>
+              </label>
+              <label>
+                  SSS
+                  <input type="radio" name="technicalRankBonus" value="SSS" checked={technicalRankBonus === "SSS"} onClick={this.handleTechnicalRadio} readOnly/> 
+              </label>
+              <label>
+                  SS
+                  <input type="radio" name="technicalRankBonus" value="SS" checked={technicalRankBonus === "SS"} onClick={this.handleTechnicalRadio} readOnly/>
+              </label>
             </div>
 
 
+            <div className="vertical-radio-buttons">
+              Clear Badge
+              <label>
+                All Break+
+                <input type="radio" name="clearBadge" value="All Break+" checked={clearBadge === "All Break+"} onClick={this.handleClearRadio} readOnly/>
+              </label>
 
-        <div className="vertical-radio-buttons">
-        Clear Badge
+              <label>
+                All Break
+                <input type="radio" name="clearBadge" value="All Break" checked={clearBadge === "All Break"} onClick={this.handleClearRadio} readOnly/>
+              </label>
 
-        <label>
-        All Break+
-        <input
-          id="windows"
-          value="All Break+"
-          name="platform"
-          type="radio"
-          onChange={this.handleChange}
-        />
-        </label>
+              <label>
+                Full Combo
+                <input type="radio" name="clearBadge" value="Full Combo" checked={clearBadge === "Full Combo"} onClick={this.handleClearRadio} readOnly/>
+              </label>
 
-        <label>
+              Full Bell
+              <input type="checkbox" name="fullBell" onChange={this.handleCheckbox} checked={this.state.fullBell}/>
+            </div>
 
-        All Break
-        <input
-          id="mac"
-          value="All Break"
-          name="platform"
-          type="radio"
-          onChange={this.handleChange}
-        />
-                </label>
-
-                <label>
-
-        Full Combo
-        <input
-          id="linux"
-          value="Full Combo"
-          name="platform"
-          type="radio"
-          onChange={this.handleChange}
-        />
-        </label>
-
-        Full Bell
-        <input
-            type="checkbox"
-        />
+          </form>
+          
+          {/* <input type="file" accept=".json" onChange={this.handleFileChange} /> */}
         </div>
-
-        <label>Platinum Score</label>
-          <input
-            type="number"
-            name={"critical"}
-            value={this.state.critical}
-            onChange={this.handleChange}
-          ></input>
-
-
-
+        
+        <div>
+        Base Rating: {this.state.baseRating.toFixed(2)}
+        </div>
+        
+        <form style={divStyle}>
+        
+          <label>Platinum Score</label>
+            <input
+              type="number"
+              name={"platinumScore"}
+              value={this.state.platinumScore}
+              onChange={this.handleChange}
+            />
         </form>
-
-<button>Get Rating</button>
-
-<input type="file" accept=".json" onChange={this.handleFileChange} />
-       </div>
+        Platinum Rating: {this.state.platinumRating.toFixed(2)}
+      </div>
     )
 }
 }

--- a/src/scoresimulatorV2.js
+++ b/src/scoresimulatorV2.js
@@ -1,0 +1,217 @@
+import React, { Component } from "react";
+import "./App.css";
+
+class ScoreSimulatorV2 extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      values: null,
+      critical: 0,
+      break: 0,
+      hit: 0,
+      miss: 0,
+      bell: 1,
+      totalBell: 1,
+      damage: 0,
+      score: 0,
+      chart: 1,
+      score2: 0,
+      rating: 0,
+      userName: null,
+      version: null,
+      score2Once: false
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.values !== undefined) {
+      this.setState({
+        critical: this.props.values[0],
+        break: this.props.values[1],
+        hit: this.props.values[2],
+        miss: this.props.values[3],
+        bell: this.props.values[4],
+        totalBell: this.props.values[5],
+        damage: this.props.values[6],
+        chart: this.props.values[7],
+        score2: this.props.values[8]
+    })
+    }
+  }
+  componentDidUpdate() {
+    let notePercent =
+      this.state.critical * 1 +
+      this.state.break * 0.9 +
+      this.state.hit * 0.6 +
+      this.state.miss * 0;
+    let totalNotes =
+      this.state.critical * 1 +
+      this.state.break * 1 +
+      this.state.hit * 1 +
+      this.state.miss * 1;
+    let acc = notePercent / totalNotes;
+    let noteScore = 950000 * acc;
+    let bellScore = (this.state.bell / this.state.totalBell) * 60000;
+    let damageScore = this.state.damage * 10;
+    let totalScore = this.state.score;
+    totalScore = noteScore + bellScore - damageScore;
+
+    let musicRate;
+    if (this.state.score2 >= 1007500) {
+      musicRate = 2;
+    } else if (this.state.score2 >= 1000000) {
+      musicRate = 1.5 + (this.state.score2 - 1000000) / 15000;
+    } else if (this.state.score2 >= 990000) {
+      musicRate = 1 + (this.state.score2 - 990000) / 20000;
+    } else if (this.state.score2 >= 970000) {
+      musicRate = (this.state.score2 - 970000) / 20000;
+    } else {
+      musicRate = (this.state.score2 - 970000) / 17500;
+    }
+    musicRate += this.state.chart * 1;
+
+    if (totalScore !== this.state.score && !isNaN(totalScore)) {
+      this.setState({ score: totalScore });
+    }
+
+    if ((musicRate !== this.state.rating) && !isNaN(musicRate)) {
+      this.setState({ rating: musicRate });
+    }
+  }
+
+  
+  handleChange = (e) => {
+    this.setState({ [e.target.name]: e.target.value });
+  };
+
+  handleBack = () => {
+    //hacky solution I love react! 
+   window.location = `https://ongekiers.netlify.app/${this.props.userName}/${this.props.version}`
+  }
+
+    handleFileChange = (event) => {
+    const file = event.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+            const jsonString = e.target.result;
+            const jsonData = JSON.parse(jsonString);
+            // Handle the jsonData here
+            console.log(jsonData);
+        } catch (error) {
+          console.error("Error parsing JSON:", error);
+        }
+  
+      };
+      reader.readAsText(file);
+    }
+  };
+
+  render() {
+
+    return( 
+        <div className="divStyle">
+        <form>
+        <label>Chart Rating</label>
+
+          <input
+            type="number"
+            name={"critical"}
+            value={this.state.critical}
+            onChange={this.handleChange}
+          ></input>
+
+        <label>Score</label>
+          <input
+            type="number"
+            name={"critical"}
+            value={this.state.critical}
+            onChange={this.handleChange}
+          ></input>
+
+
+
+        <div className="vertical-radio-buttons">
+            Technical Rank Bonus
+            <label>
+                SSS+
+                <input type="radio" name="choice" value="A" />
+            </label>
+            <label>
+                SSS
+                <input type="radio" name="choice" value="B" /> 
+            </label>
+            <label>
+                SS
+                <input type="radio" name="choice" value="C" />
+            </label>
+            </div>
+
+
+
+        <div className="vertical-radio-buttons">
+        Clear Badge
+
+        <label>
+        All Break+
+        <input
+          id="windows"
+          value="All Break+"
+          name="platform"
+          type="radio"
+          onChange={this.handleChange}
+        />
+        </label>
+
+        <label>
+
+        All Break
+        <input
+          id="mac"
+          value="All Break"
+          name="platform"
+          type="radio"
+          onChange={this.handleChange}
+        />
+                </label>
+
+                <label>
+
+        Full Combo
+        <input
+          id="linux"
+          value="Full Combo"
+          name="platform"
+          type="radio"
+          onChange={this.handleChange}
+        />
+        </label>
+
+        Full Bell
+        <input
+            type="checkbox"
+        />
+        </div>
+
+        <label>Platinum Score</label>
+          <input
+            type="number"
+            name={"critical"}
+            value={this.state.critical}
+            onChange={this.handleChange}
+          ></input>
+
+
+
+        </form>
+
+<button>Get Rating</button>
+
+<input type="file" accept=".json" onChange={this.handleFileChange} />
+       </div>
+    )
+}
+}
+
+export default ScoreSimulatorV2;


### PR DESCRIPTION
- The score simulator calculator for Ongeki Re:Fresh on `/scoresimulatorv2` now works
- All inputs function for chart rating, technical score, technical rank, clear badges, full bell, and platinum score now work to calculate a play's base rating and platinum rating based on the writeup on this [blog post](https://listed.to/@donmai/60600/ongeki-re-fresh-s-new-rating-system)
- The radio buttons for technical rank and clear badges are toggleable
- The calculation dynamically responds to changing inputs, akin to the first score simulator